### PR TITLE
Kill chickens with zombies riding them

### DIFF
--- a/data/no-monster/functions/kill_mobs/kill_undead.mcfunction
+++ b/data/no-monster/functions/kill_mobs/kill_undead.mcfunction
@@ -1,3 +1,4 @@
+execute as @e[type=chicken,nbt={Passengers:[{id:"minecraft:zombie"}]}] run function no-monster:remove_mob_self
 execute as @e[type=drowned] run function no-monster:remove_mob_self
 execute as @e[type=husk] run function no-monster:remove_mob_self
 execute as @e[type=phantom] run function no-monster:remove_mob_self


### PR DESCRIPTION
Due to MC limitations, the baby zombie will remain alive, however it is then killed by the normal selector targeting zombies.

This prevents a buildup of chickens in the world, and fixes #9.
